### PR TITLE
Fix project language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/resources/* linguist-vendored


### PR DESCRIPTION
Githubs linguist see generated resources inside the test/resources folder. Because complates generated views (as plain javascript) resides there, this project is classified as Javascript by Github. Which is definitivly wrong.

Found on the net that it is possible to exclude folders, so i exclude the test/resources folder from the stats.